### PR TITLE
:sparkles: Be android 10 compatible

### DIFF
--- a/Smartway.UiComponent.Droid/Extensions/EntryExtension.cs
+++ b/Smartway.UiComponent.Droid/Extensions/EntryExtension.cs
@@ -1,0 +1,33 @@
+﻿using Android.OS;
+using Android.Runtime;
+using Android.Widget;
+using Xamarin.Forms.Platform.Android;
+
+namespace Smartway.UiComponent.Droid.Extensions
+{
+    public static class EntryExtension
+    {
+        public static void RemoveHintBottomLine(this FormsEditText control)
+        {
+            control.SetBackground(null);
+        }
+
+        public static void SetCursorColor(this FormsEditText control)
+        {
+            if (control == null)
+                return;
+
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.Q)
+            {
+                //This API Intrduced in android 10
+                control.SetTextCursorDrawable(Resource.Drawable.cursor); 
+            }
+            else
+            {
+                var intPtrtextViewClass = JNIEnv.FindClass(typeof(TextView));
+                var mCursorDrawableResProperty = JNIEnv.GetFieldID(intPtrtextViewClass, "mCursorDrawableRes", "I");
+                JNIEnv.SetField(control.Handle, mCursorDrawableResProperty, Resource.Drawable.cursor);
+            }
+        }
+    }
+}

--- a/Smartway.UiComponent.Droid/Renderers/BarcodeEntryRenderer.cs
+++ b/Smartway.UiComponent.Droid/Renderers/BarcodeEntryRenderer.cs
@@ -2,8 +2,7 @@
 using Android.Content.Res;
 using Android.Graphics;
 using Android.OS;
-using Android.Runtime;
-using Android.Widget;
+using Smartway.UiComponent.Droid.Extensions;
 using Smartway.UiComponent.Droid.Renderers;
 using Smartway.UiComponent.Inputs.Barcode;
 using Xamarin.Forms;
@@ -26,14 +25,7 @@ namespace Smartway.UiComponent.Droid.Renderers
                 return;
 
             RemoveHintBottomLine();
-            SetCursorColor();
-        }
-
-        private void SetCursorColor()
-        {
-            var intPtrtextViewClass = JNIEnv.FindClass(typeof(TextView));
-            var mCursorDrawableResProperty = JNIEnv.GetFieldID(intPtrtextViewClass, "mCursorDrawableRes", "I");
-            JNIEnv.SetField(Control.Handle, mCursorDrawableResProperty, Resource.Drawable.cursor);
+            Control.SetCursorColor();
         }
 
         private void RemoveHintBottomLine()

--- a/Smartway.UiComponent.Droid/Renderers/CustomEntryRenderer.cs
+++ b/Smartway.UiComponent.Droid/Renderers/CustomEntryRenderer.cs
@@ -3,10 +3,9 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Android.Content;
 using Android.Graphics.Drawables;
-using Android.Runtime;
 using Android.Text;
 using Android.Text.Method;
-using Android.Widget;
+using Smartway.UiComponent.Droid.Extensions;
 using Smartway.UiComponent.Droid.Renderers;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
@@ -28,7 +27,7 @@ namespace Smartway.UiComponent.Droid.Renderers
                 return;
 
             var gd = new GradientDrawable();
-            gd.SetColor(global::Android.Graphics.Color.Transparent);
+            gd.SetColor(Android.Graphics.Color.Transparent);
 
             Control.SetPadding(0, 0, Control.PaddingRight, 0);
 
@@ -41,8 +40,8 @@ namespace Smartway.UiComponent.Droid.Renderers
             if (e.OldElement != null)
                 return;
 
-            RemoveHintBottomLine();
-            SetCursorColor();
+            Control.RemoveHintBottomLine();
+            Control.SetCursorColor();
         }
 
         private const string DecimalRegEx = @"^\d+((\.|\,){1})?\d*$";
@@ -63,18 +62,6 @@ namespace Smartway.UiComponent.Droid.Renderers
                 return;
 
             control.Text = control.Text.Replace(lastChar.ToString(), cultureDecimalSeparator);
-        }
-
-        private void SetCursorColor()
-        {
-            var IntPtrtextViewClass = JNIEnv.FindClass(typeof(TextView));
-            var mCursorDrawableResProperty = JNIEnv.GetFieldID(IntPtrtextViewClass, "mCursorDrawableRes", "I");
-            JNIEnv.SetField(Control.Handle, mCursorDrawableResProperty, Resource.Drawable.cursor);
-        }
-
-        private void RemoveHintBottomLine()
-        {
-            this.Control.SetBackground(null);
         }
     }
 }

--- a/Smartway.UiComponent.Droid/Smartway.UiComponent.Droid.csproj
+++ b/Smartway.UiComponent.Droid/Smartway.UiComponent.Droid.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Effects\AndroidCustomTapEffect.cs" />
     <Compile Include="Effects\AndroidHoldTapEffect.cs" />
+    <Compile Include="Extensions\EntryExtension.cs" />
     <Compile Include="Renderers\BarcodeEntryRenderer.cs" />
     <Compile Include="Renderers\CustomButtonRenderer.cs" />
     <Compile Include="Renderers\CustomEntryRenderer.cs" />


### PR DESCRIPTION
L'attribut mCursorDrawableRes n'existe plus il faut passer par la nouvelle Api.
J'en ai profité pour exposer les méthodes pour pouvoir également l'utiliser dans le prjet Zg.Remote qui utilise exactement le même code...