### PR TITLE
Feature/make date picker compatible with android6

### DIFF
--- a/Smartway.UiComponent.Droid/Services/AndroidInfoProvider.cs
+++ b/Smartway.UiComponent.Droid/Services/AndroidInfoProvider.cs
@@ -1,0 +1,12 @@
+﻿using Android.OS;
+using Smartway.UiComponent.Droid.Services;
+using Smartway.UiComponent.Services;
+
+[assembly: Xamarin.Forms.Dependency(typeof(AndroidInfoProvider))]
+namespace Smartway.UiComponent.Droid.Services
+{
+    public class AndroidInfoProvider : IPlatormInfoProvider
+    {
+        public int OsSdkVersion { get { return ((int)Build.VERSION.SdkInt); } }
+    }
+}

--- a/Smartway.UiComponent.Droid/Smartway.UiComponent.Droid.csproj
+++ b/Smartway.UiComponent.Droid/Smartway.UiComponent.Droid.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Renderers\NoDialogDatePickerRenderer.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\AndroidInfoProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\font\open_sans_regular.ttf" />

--- a/Smartway.UiComponent.Sample/Smartway.UiComponent.Sample.csproj
+++ b/Smartway.UiComponent.Sample/Smartway.UiComponent.Sample.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2196" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Smartway.UiComponent/Inputs/RoundedDatePicker.xaml
+++ b/Smartway.UiComponent/Inputs/RoundedDatePicker.xaml
@@ -1,15 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cards="clr-namespace:Smartway.UiComponent.Cards;assembly=Smartway.UiComponent" 
-             xmlns:inputs="clr-namespace:Smartway.UiComponent.Inputs"
-             x:Class="Smartway.UiComponent.Inputs.RoundedDatePicker"
-             x:Name="Self">
-    <cards:RoundedFrame Padding="0" HasShadow="False">
-        <inputs:NoDialogDatePicker
-            HeightRequest="172"
-            Date="{Binding Source={x:Reference Self}, Path=Date}"
-            MinimumDate="{Binding Source={x:Reference Self}, Path=MinimumDate}"
-            MaximumDate="{Binding Source={x:Reference Self}, Path=MaximumDate}"/>
-    </cards:RoundedFrame>
+             xmlns:cards="clr-namespace:Smartway.UiComponent.Cards;assembly=Smartway.UiComponent"
+             x:Class="Smartway.UiComponent.Inputs.RoundedDatePicker">
+    <cards:RoundedFrame x:Name="RoundedFrame" Padding="0" HasShadow="False" />
 </ContentView>

--- a/Smartway.UiComponent/Inputs/RoundedDatePicker.xaml.cs
+++ b/Smartway.UiComponent/Inputs/RoundedDatePicker.xaml.cs
@@ -1,18 +1,19 @@
 ﻿using System;
-
+using Smartway.UiComponent.Services;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace Smartway.UiComponent.Inputs
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class RoundedDatePicker : ContentView
+    public partial class RoundedDatePicker
     {
         public RoundedDatePicker()
         {
             InitializeComponent();
+            InitializeDatePicker();
         }
-  
+
         public static readonly BindableProperty DateProperty =
             BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(RoundedDatePicker), defaultBindingMode: BindingMode.TwoWay);
 
@@ -24,7 +25,7 @@ namespace Smartway.UiComponent.Inputs
 
         public DateTime Date
         {
-            get => (DateTime) GetValue(DateProperty);
+            get => (DateTime)GetValue(DateProperty);
             set => SetValue(DateProperty, value);
         }
 
@@ -38,6 +39,16 @@ namespace Smartway.UiComponent.Inputs
         {
             get => (DateTime)GetValue(MaximumDateProperty);
             set => SetValue(MaximumDateProperty, value);
+        }
+
+        private void InitializeDatePicker()
+        {
+            var platformInfo = DependencyService.Get<IPlatormInfoProvider>();
+            var datePicker = platformInfo.OsSdkVersion <= 23 ? new DatePicker() : new NoDialogDatePicker { HeightRequest = 172 };
+            datePicker.SetBinding(DatePicker.DateProperty, new Binding("Date", source: this));
+            datePicker.SetBinding(DatePicker.MaximumDateProperty, new Binding("MaximumDate", source: this));
+            datePicker.SetBinding(DatePicker.MinimumDateProperty, new Binding("MinimumDate", source: this));
+            RoundedFrame.Content = datePicker;
         }
     }
 }

--- a/Smartway.UiComponent/Services/IPlatormInfoProvider.cs
+++ b/Smartway.UiComponent/Services/IPlatormInfoProvider.cs
@@ -1,0 +1,10 @@
+﻿namespace Smartway.UiComponent.Services
+{
+    public interface IPlatormInfoProvider
+    {
+        /// <summary>
+        /// Return current os sdk version
+        /// </summary>
+        int OsSdkVersion { get; }
+    }
+}


### PR DESCRIPTION
DatepickerNoDialog pas compatible avec les version d'Android 6

Sur Android 6
![android_6](https://user-images.githubusercontent.com/8371625/141455908-525867e4-3acc-4295-a97d-1f1e091167f5.gif)

Sur version supérieur à 6
![android_sup6](https://user-images.githubusercontent.com/8371625/141455914-47cf4b85-0138-4a92-b8b0-419dad28d7d7.gif)
