### PR TITLE
Fix display of indicator in article card when scanning several articles in a row

### DIFF
--- a/Smartway.UiComponent/Cards/ArticleCard.xaml
+++ b/Smartway.UiComponent/Cards/ArticleCard.xaml
@@ -4,6 +4,7 @@
              xmlns:indicators="clr-namespace:Smartway.UiComponent.Indicators;assembly=Smartway.UiComponent"
              xmlns:resources="clr-namespace:Smartway.UiComponent.Resources;assembly=Smartway.UiComponent"
              xmlns:utils="clr-namespace:Smartway.UiComponent.Utils;assembly=Smartway.UiComponent"
+             xmlns:converters="clr-namespace:Smartway.Mvvm.Converters;assembly=Smartway.Mvvm"
              x:Class="Smartway.UiComponent.Cards.ArticleCard"
              x:Name="Self">
     <ContentView.Resources>
@@ -30,6 +31,7 @@
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
+        <converters:NullToBooleanConverter x:Key="FalseIfNull" />
     </ContentView.Resources>
     <ContentView.Content>
         <StackLayout Orientation="Vertical">
@@ -86,16 +88,15 @@
                         TextColor="Black"
                         Text="{Binding Source={Reference Self}, Path=OnShortageSince, StringFormat='Rupture depuis le {0:dd/MM/yyyy}'}"
                         IsVisible="{Binding Source={Reference Self}, Path=DisplayOnShortageSince}" />
-                    <indicators:Status IsVisible="False" HorizontalOptions="StartAndExpand">
+                    <indicators:Status IsVisible="{Binding Source={Reference Self}, Path=Status, Converter={StaticResource FalseIfNull}}" 
+                                       HorizontalOptions="StartAndExpand">
                         <indicators:Status.Triggers>
                             <DataTrigger TargetType="indicators:Status" Binding="{Binding Source={Reference Self}, Path=Status}" Value="Monitored">
                                 <Setter Property="Value" Value="Success" />
-                                <Setter Property="IsVisible" Value="True" />
                                 <Setter Property="Text" Value="{x:Static resources:Resources.Monitor}" />
                             </DataTrigger>
                             <DataTrigger TargetType="indicators:Status" Binding="{Binding Source={Reference Self}, Path=Status}" Value="Unmonitored">
                                 <Setter Property="Value" Value="Basic" />
-                                <Setter Property="IsVisible" Value="True" />
                                 <Setter Property="Text" Value="{x:Static resources:Resources.Unmonitor}" />
                             </DataTrigger>
                         </indicators:Status.Triggers>

--- a/Smartway.UiComponent/Cards/ArticleCard.xaml.cs
+++ b/Smartway.UiComponent/Cards/ArticleCard.xaml.cs
@@ -16,7 +16,7 @@ namespace Smartway.UiComponent.Cards
         public static readonly BindableProperty NavigationCommandProperty = BindableProperty.Create(nameof(NavigationCommand), typeof(ICommand), typeof(ArticleCard));
         public static readonly BindableProperty NavigationParameterProperty = BindableProperty.Create(nameof(NavigationParameter), typeof(object), typeof(ArticleCard));
         public static readonly BindableProperty OnShortageSinceProperty = BindableProperty.Create(nameof(OnShortageSince), typeof(DateTime?), typeof(ArticleCard), DateTime.Today);
-        public static readonly BindableProperty StatusProperty = BindableProperty.Create(nameof(Status), typeof(string), typeof(ArticleCard), "Unknown");
+        public static readonly BindableProperty StatusProperty = BindableProperty.Create(nameof(Status), typeof(string), typeof(ArticleCard));
         public static readonly BindableProperty IsCondensedProperty = BindableProperty.Create(nameof(IsCondensed), typeof(bool), typeof(ArticleCard), false);
 
         public bool IsMultilocation

--- a/Smartway.UiComponent/Smartway.UiComponent.csproj
+++ b/Smartway.UiComponent/Smartway.UiComponent.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Smartway.Barcode" Version="0.1.0" />
     <PackageReference Include="Smartway.ValueObjects" Version="0.3.0" />
-    <PackageReference Include="Smartway.Mvvm" Version="0.2.0" />
+    <PackageReference Include="Smartway.Mvvm" Version="0.4.0" />
     <PackageReference Include="Xamarin.CommunityToolkit" Version="1.2.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>


### PR DESCRIPTION
Cette PR corrige le problème d'affichage du statut sur l'article card lorsqu'on scanne à la suite un produit non monitoré puis monitoré.
Le problème semble venir du double DataTrigger qui set chacun la valeur de IsVisible à True qui n'est pas la valeur par défaut (cf ici :https://github.com/xamarin/Xamarin.Forms/issues/1412)