### PR TITLE
✨ Add a CenteredTopAppBar

### DIFF
--- a/Smartway.UiComponent.Sample/TopAppBar/Views/TopAppBar.xaml
+++ b/Smartway.UiComponent.Sample/TopAppBar/Views/TopAppBar.xaml
@@ -13,6 +13,10 @@
             <Label Text="Default"/>
             <topappbar:TopAppBar Title="Product 1"
                                  Command="{Binding Back}"/>
+            <Label Text="Default centered"/>
+            <topappbar:TopAppBar Title="Product 1"
+                                 IsTitleCentered="True"
+                                 Command="{Binding Back}"/>
             <Label Text="Modal"/>
             <topappbar:TopAppBar Title="Product 2"
                                  Type="Modal"

--- a/Smartway.UiComponent/TopAppBar/TopAppBar.xaml
+++ b/Smartway.UiComponent/TopAppBar/TopAppBar.xaml
@@ -19,12 +19,10 @@
                 <Setter Property="VerticalOptions" Value="Center"/>
                 <Setter Property="TextColor" Value="{StaticResource ZgDarkBlue}"/>
                 <Setter Property="FontSize" Value="24"/>
-                <Setter Property="Margin" Value="0, 0, 16, 0"/>
             </Style>
             <Style x:Key="LabelTitle" TargetType="Label" BasedOn="{StaticResource SemiBoldFont}">
                 <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Margin" Value="16, 0, 0, 0"/>
-                <Setter Property="HorizontalTextAlignment" Value="Start"/>
+                <Setter Property="HorizontalTextAlignment" Value="Center"/>
                 <Setter Property="HorizontalOptions" Value="StartAndExpand"/>
                 <Setter Property="VerticalTextAlignment" Value="Center"/>
                 <Setter Property="LineBreakMode" Value="TailTruncation"/>
@@ -32,20 +30,30 @@
             <Style x:Key="ExtraLabel" TargetType="Label" BasedOn="{StaticResource SemiBoldFont}">
                 <Setter Property="FontSize" Value="16"/>
                 <Setter Property="VerticalTextAlignment" Value="Center"/>
-                <Setter Property="Padding" Value="0, 1, 0, 0"/>
+                <Setter Property="HorizontalTextAlignment" Value="End"/>
+                <Setter Property="Padding" Value="0, 0, 16, 0"/>
+            </Style>
+            <Style x:Key="LeftTopAppBar" TargetType="Grid">
+                <Setter Property="RowDefinitions" Value="48"/>
+                <Setter Property="ColumnSpacing" Value="16"/>
+                <Setter Property="ColumnDefinitions" Value="Auto, *, Auto"/>
+            </Style>
+            <Style x:Key="CenteredTopAppBar" TargetType="Grid">
+                <Setter Property="RowDefinitions" Value="48"/>
+                <Setter Property="ColumnSpacing" Value="16"/>
+                <Setter Property="ColumnDefinitions" Value="1*, 3*, 1*"/>
             </Style>
         </ResourceDictionary>
     </ContentView.Resources>
     <ContentView.Content>
-        <Grid Padding="0, 3, 16, 5" ColumnSpacing="0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="48" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+        <Grid Style="{StaticResource LeftTopAppBar}">
+            <Grid.Triggers>
+                <DataTrigger TargetType="Grid"
+                             Binding="{Binding Source={x:Reference Self}, Path=IsTitleCentered}"
+                             Value="True">
+                    <Setter Property="Style" Value="{StaticResource CenteredTopAppBar}"/>
+                </DataTrigger>
+            </Grid.Triggers>
             <layouts:ClickableItem Padding="16, 0, 0, 0">
                 <layouts:ClickableItem.GestureRecognizers>
                     <TapGestureRecognizer
@@ -131,7 +139,15 @@
             <Label Grid.Column="1"
                    Style="{StaticResource LabelTitle}"
                    Text="{Binding Source={x:Reference Self}, Path=Title}"
-                   AutomationId="TopNavigationHeader"/>
+                   AutomationId="TopNavigationHeader">
+                <Label.Triggers>
+                    <DataTrigger TargetType="Label"
+                                 Binding="{Binding Source={x:Reference Self}, Path=IsTitleCentered}"
+                                 Value="True">
+                        <Setter Property="HorizontalOptions" Value="CenterAndExpand"/>
+                    </DataTrigger>
+                </Label.Triggers>
+            </Label>
             <Label Grid.Column="2"
                    Style="{StaticResource ExtraLabel}"
                    Text="{Binding Source={x:Reference Self}, Path=ExtraNavigationLabel}"

--- a/Smartway.UiComponent/TopAppBar/TopAppBar.xaml.cs
+++ b/Smartway.UiComponent/TopAppBar/TopAppBar.xaml.cs
@@ -9,6 +9,7 @@ namespace Smartway.UiComponent.TopAppBar
     public partial class TopAppBar
     {
         public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(TopAppBar));
+        public static readonly BindableProperty IsTitleCenteredProperty = BindableProperty.Create(nameof(IsTitleCentered), typeof(bool), typeof(TopAppBar));
         public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(TopAppBar));
         public static readonly BindableProperty TypeProperty = BindableProperty.Create(nameof(Type), typeof(string), typeof(TopAppBar), "Default");
         public static readonly BindableProperty ExtraNavigationLabelProperty = BindableProperty.Create(nameof(ExtraNavigationLabel), typeof(string), typeof(TopAppBar));
@@ -21,6 +22,11 @@ namespace Smartway.UiComponent.TopAppBar
         {
             get => (string)GetValue(TitleProperty);
             set => SetValue(TitleProperty, value);
+        }
+        public bool IsTitleCentered
+        {
+            get => (bool)GetValue(IsTitleCenteredProperty);
+            set => SetValue(IsTitleCenteredProperty, value);
         }
         public ICommand Command
         {


### PR DESCRIPTION
This component aims at having a top app bar with the ability to have the title perfectly centered. With the classic TopAppBar, we can't do that, we need an absolute layout.



Proposition de nouveau composant pour avoir une TopAppBar avec titre centré.
J'ai préféré re créer un composant plutôt que d'essayer d'adapter l'existant. A noter qu'avec cette CenteredTopAppBar on contraint de fait la taille des éléments, et en particulier on ne peut pas avoir un titre d'ExtraNavigation trop long. Pour le moment il n'est pas physiquement contraint mais c'est faisable.
On pourrait aussi tout simplement virer l'extra navigation pour l'instant car cette CenteredTopAppBar n'a pas vocation à être utilisée avec ce troisième bouton.

Pour le contexte voir en dessous :
![image](https://user-images.githubusercontent.com/84324109/183047803-73c4f646-cc7a-43ef-942e-01c5365ef6f3.png)
