### PR TITLE
:bug: :lipstick: NumericDateEntry - Fix spanish format

### DIFF
--- a/Smartway.UiComponent.UnitTests/Inputs/NumericDateInput/NumericDateEntryTest.cs
+++ b/Smartway.UiComponent.UnitTests/Inputs/NumericDateInput/NumericDateEntryTest.cs
@@ -14,38 +14,18 @@ namespace Smartway.UiComponent.UnitTests.Inputs.NumericDateEntryTest
 {
     public class NumericDateEntryTest
     {
-        protected NumericDateEntry _numericDateEntry { get; set; }
+        private Mock<ICommand> _errorCommandMock { get; set; }
 
         public NumericDateEntryTest()
         {
             MockForms.Init();
-        }
-
-        public void SetDateToDatepicker(string day, string month, string year)
-        {
-            _numericDateEntry.DayEntry.Text = day;
-            _numericDateEntry.MonthEntry.Text = month;
-            _numericDateEntry.YearEntry.Text = year;
-        }
-    }
-
-    public class GetFilledDateTest : NumericDateEntryTest
-    {
-        private Mock<ICommand> _errorCommandMock { get; set; }
-
-        public GetFilledDateTest()
-        {
             _errorCommandMock = new Mock<ICommand>();
-            _numericDateEntry = new NumericDateEntry
-            {
-                ErrorCommand = _errorCommandMock.Object,
-            };
         }
 
         [Fact]
         public void FilledCorrect()
         {
-            SetDateToDatepicker("10", "01", "22");
+            CreateNumericDateEntry("10", "01", "22");
             _errorCommandMock.Verify(mock => mock.Execute(It.IsAny<string>()), Times.Never());
         }
 
@@ -55,7 +35,7 @@ namespace Smartway.UiComponent.UnitTests.Inputs.NumericDateEntryTest
         [InlineData("10", "02", "-1")]
         public void FilledUncorrectDate(string day, string month, string year)
         {
-            SetDateToDatepicker(day, month, year);
+            CreateNumericDateEntry(day, month, year);
             _errorCommandMock.Verify(mock => mock.Execute(It.IsAny<Exception>()), Times.Once());
         }
 
@@ -102,7 +82,10 @@ namespace Smartway.UiComponent.UnitTests.Inputs.NumericDateEntryTest
 
         private NumericDateEntry CreateNumericDateEntry(string day, string month, string year)
         {
-            var numericDateEntry = new NumericDateEntry();
+            var numericDateEntry = new NumericDateEntry
+            {
+                ErrorCommand = _errorCommandMock.Object
+            };
 
             numericDateEntry.DayEntry.Text = day;
             numericDateEntry.MonthEntry.Text = month;

--- a/Smartway.UiComponent.UnitTests/Inputs/NumericDateInput/NumericDateEntryTest.cs
+++ b/Smartway.UiComponent.UnitTests/Inputs/NumericDateInput/NumericDateEntryTest.cs
@@ -4,6 +4,10 @@ using System.Windows.Input;
 using Moq;
 using Smartway.UiComponent.Inputs;
 using Xamarin.Forms.Mocks;
+using System.Globalization;
+using System.Threading;
+using NFluent;
+using Xamarin.Forms;
 
 
 namespace Smartway.UiComponent.UnitTests.Inputs.NumericDateEntryTest
@@ -25,9 +29,10 @@ namespace Smartway.UiComponent.UnitTests.Inputs.NumericDateEntryTest
         }
     }
 
-    public class GetFilledDateTest: NumericDateEntryTest
+    public class GetFilledDateTest : NumericDateEntryTest
     {
         private Mock<ICommand> _errorCommandMock { get; set; }
+
         public GetFilledDateTest()
         {
             _errorCommandMock = new Mock<ICommand>();
@@ -52,6 +57,71 @@ namespace Smartway.UiComponent.UnitTests.Inputs.NumericDateEntryTest
         {
             SetDateToDatepicker(day, month, year);
             _errorCommandMock.Verify(mock => mock.Execute(It.IsAny<Exception>()), Times.Once());
+        }
+
+        [Theory]
+        [InlineData("fr-FR", "JJ", "MM", "AA")]
+        [InlineData("es-ES", "JJ", "MM", "AA")]
+        [InlineData("it-IT", "JJ", "MM", "AA")]
+        [InlineData("ru-RU", "JJ", "MM", "AA")]
+        [InlineData("ro-RO", "JJ", "MM", "AA")]
+        [InlineData("us-US", "DD", "MM", "YY")]
+        [InlineData("en-EN", "DD", "MM", "YY")]
+        public void DefaultPlaceholder(string culture, string day, string month, string year)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            var numericDateEntry = new NumericDateEntry();
+
+            Check.That(numericDateEntry.DayEntry.Placeholder).IsEqualTo(day);
+            Check.That(numericDateEntry.MonthEntry.Placeholder).IsEqualTo(month);
+            Check.That(numericDateEntry.YearEntry.Placeholder).IsEqualTo(year);
+        }
+
+        [Theory]
+        [InlineData("fr-FR", "06", "10")]
+        [InlineData("es-ES", "06", "10")]
+        [InlineData("it-IT", "06", "10")]
+        [InlineData("ro-RO", "06", "10")]
+        [InlineData("ru-RU", "06", "10")]
+        [InlineData("us-US", "10", "06")]
+        [InlineData("en-EN", "10", "06")]
+        public void MonthDayOrderCulture(string culture, string expectedFirst, string expectedSecond)
+        {
+            SetCulture(culture);
+
+            var entry = CreateNumericDateEntry("06", "10", "2022");
+
+            CheckNumericDateEntry(entry, expectedFirst, expectedSecond, "2022");
+        }
+
+        private void SetCulture(string culture)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
+        }
+
+        private NumericDateEntry CreateNumericDateEntry(string day, string month, string year)
+        {
+            var numericDateEntry = new NumericDateEntry();
+
+            numericDateEntry.DayEntry.Text = day;
+            numericDateEntry.MonthEntry.Text = month;
+            numericDateEntry.YearEntry.Text = year;
+
+            return numericDateEntry;
+        }
+
+        private void CheckNumericDateEntry(NumericDateEntry entry, string expectedFirst, string expectedSecond, string expectedThird)
+        {
+            CheckEntry(entry, "FirstEntry", expectedFirst);
+            CheckEntry(entry, "SecondEntry", expectedSecond);
+            CheckEntry(entry, "ThirdEntry", expectedThird);
+        }
+
+        private void CheckEntry(NumericDateEntry entry, string name, string expectedValue)
+        {
+            var value = (Entry)entry.FindByName(name);
+            Check.That(value.Text).IsEqualTo(expectedValue);
         }
     }
 }

--- a/Smartway.UiComponent/Inputs/NumericDateEntry.xaml.cs
+++ b/Smartway.UiComponent/Inputs/NumericDateEntry.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows.Input;
@@ -200,9 +200,9 @@ namespace Smartway.UiComponent.Inputs
 
         private bool DateTimeIsNull(DateTime date)
         {
-            // null value of datetime is a datetime at 01/01/01
-            return date.Year == 1;
+            return date.Year == DateTime.MinValue.Year;
         }
+
         private void SetDefaultPlaceholder()
         {
             if (IsDayMonthCalendar())
@@ -223,7 +223,7 @@ namespace Smartway.UiComponent.Inputs
         {
             var calendarType =
                 CultureInfo.GetCultureInfo(CultureInfo.CurrentCulture.Name).DateTimeFormat.MonthDayPattern;
-            return calendarType == "d MMMM";
+            return calendarType.IndexOf("d") < calendarType.IndexOf("M");
         }
 
         private void OnFocusedSelectAllEntryContent(object sender, FocusEventArgs e)


### PR DESCRIPTION
The spanish format was displayed as mm/dd/yy because we were checking if the clutur format if it is 'd MMMM' although the spanish format is 'd de MMMM'

![date_entry](https://user-images.githubusercontent.com/24730716/194280170-e1af7265-0d81-46e7-9388-8eb2e645da84.gif)

