### PR TITLE
feat(ProductCard): add optional ShopCode field before gencode/price line

### DIFF
--- a/Smartway.UiComponent.Sample/SectionSheet/Views/SectionSheetSample.xaml
+++ b/Smartway.UiComponent.Sample/SectionSheet/Views/SectionSheetSample.xaml
@@ -79,6 +79,7 @@
                                        InitialPrice="2€25"
                                        IsMultilocation="True"
                                        Quantity="6"
+                                       ShopCode="123456"
                                        Time="02:55"
                                        ClickCommand="{Binding DisplayToastCommand}"/>
                     <cards:ProductCard Label="Cuisse de Dinde"

--- a/Smartway.UiComponent/Cards/ArticleCard.xaml
+++ b/Smartway.UiComponent/Cards/ArticleCard.xaml
@@ -5,6 +5,7 @@
              xmlns:resources="clr-namespace:Smartway.UiComponent.Resources;assembly=Smartway.UiComponent"
              xmlns:utils="clr-namespace:Smartway.UiComponent.Utils;assembly=Smartway.UiComponent"
              xmlns:converters="clr-namespace:Smartway.Mvvm.Converters;assembly=Smartway.Mvvm"
+             xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
              x:Class="Smartway.UiComponent.Cards.ArticleCard"
              x:Name="Self">
     <ContentView.Resources>
@@ -29,6 +30,7 @@
                         <Setter Property="FontAttributes" Value="None"/>
                         <Setter Property="TextColor" Value="{StaticResource ZgNightGrey}"/>
                     </Style>
+                    <xct:IsNotNullOrEmptyConverter x:Key="IsNotNullOrEmptyConverter"/>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -50,6 +52,12 @@
                     IsVisible="{Binding Source={Reference Self}, Path=IsMultilocation}"/>
             </StackLayout>
             <StackLayout Orientation="Horizontal"  VerticalOptions="EndAndExpand">
+                <Label Style="{StaticResource RegularGencodeText}"
+                    IsVisible="{Binding Source={Reference Self}, Path=ShopCode, Converter={StaticResource IsNotNullOrEmptyConverter}}"
+                    Text="{Binding Source={Reference Self}, Path=ShopCode}"
+                    AutomationId="ProductShopCode"/>
+                <Label Style="{StaticResource RegularGencodeText}" FontSize="13" Text=" · "
+                    IsVisible="{Binding Source={Reference Self}, Path=ShopCode, Converter={StaticResource IsNotNullOrEmptyConverter}}"/>
                 <Label x:Name="ProductGencode"
                     Style="{StaticResource RegularGencodeText}"
                     Text="{Binding Source={Reference Self}, Path=Gencode}"

--- a/Smartway.UiComponent/Cards/ArticleCard.xaml.cs
+++ b/Smartway.UiComponent/Cards/ArticleCard.xaml.cs
@@ -14,6 +14,7 @@ namespace Smartway.UiComponent.Cards
         public static readonly BindableProperty PriceProperty = BindableProperty.Create(nameof(Price), typeof(string), typeof(ArticleCard));
         public static readonly BindableProperty NavigationCommandProperty = BindableProperty.Create(nameof(NavigationCommand), typeof(ICommand), typeof(ArticleCard));
         public static readonly BindableProperty NavigationParameterProperty = BindableProperty.Create(nameof(NavigationParameter), typeof(object), typeof(ArticleCard));
+        public static readonly BindableProperty ShopCodeProperty = BindableProperty.Create(nameof(ShopCode), typeof(string), typeof(ArticleCard));
 
         public bool IsMultilocation
         {
@@ -49,6 +50,12 @@ namespace Smartway.UiComponent.Cards
         {
             get => (object) GetValue(NavigationParameterProperty);
             set => SetValue(NavigationParameterProperty, value);
+        }
+
+        public string ShopCode
+        {
+            get => (string)GetValue(ShopCodeProperty);
+            set => SetValue(ShopCodeProperty, value);
         }
 
         public ArticleCard()

--- a/Smartway.UiComponent/Cards/ProductCard.xaml
+++ b/Smartway.UiComponent/Cards/ProductCard.xaml
@@ -85,8 +85,12 @@
                Source="{utils:ImageResource Source=Smartway.UiComponent.Resources.Images.icon_sdet_multiimplantation.png}"
                IsVisible="{Binding Source={Reference Self}, Path=IsMultilocation}"/>
         </StackLayout>
-        <StackLayout Orientation="Horizontal">
-            <Label Style="{StaticResource GencodePriceLabel}" Margin="3, 0" AutomationId="ProductCardGencodePrice">
+        <StackLayout Orientation="Horizontal" Spacing="3">
+            <Label Style="{StaticResource GencodePriceLabel}"
+                   IsVisible="{Binding ShopCode, Source={x:Reference Self}, Converter={StaticResource IsNotNullOrEmptyConverter}}"
+                   Text="{Binding ShopCode, Source={x:Reference Self}, StringFormat='{0} •'}"
+                   AutomationId="ProductCardShopCode"/>
+            <Label Style="{StaticResource GencodePriceLabel}" AutomationId="ProductCardGencodePrice">
                 <Label.Text>
                     <MultiBinding StringFormat="{}{0} • {1}">
                         <Binding Path="Gencode" Source="{x:Reference Self}"/>

--- a/Smartway.UiComponent/Cards/ProductCard.xaml.cs
+++ b/Smartway.UiComponent/Cards/ProductCard.xaml.cs
@@ -41,6 +41,9 @@ namespace Smartway.UiComponent.Cards
         public static readonly BindableProperty IsMultilocationProperty = BindableProperty.Create(
             nameof(IsMultilocation), typeof(bool), typeof(ProductCard), false);
 
+        public static readonly BindableProperty ShopCodeProperty = BindableProperty.Create(
+            nameof(ShopCode), typeof(string), typeof(ProductCard));
+
         public ProductCard()
         {
             InitializeComponent();
@@ -110,6 +113,12 @@ namespace Smartway.UiComponent.Cards
         {
             get => (bool)GetValue(IsMultilocationProperty);
             set => SetValue(IsMultilocationProperty, value);
+        }
+
+        public string ShopCode
+        {
+            get => (string)GetValue(ShopCodeProperty);
+            set => SetValue(ShopCodeProperty, value);
         }
     }
 }


### PR DESCRIPTION
Display format becomes [shopCode •] gencode • price when ShopCode is set. The ShopCode label is hidden when the value is null or empty.